### PR TITLE
Add basic github actions

### DIFF
--- a/.github/workflows/linkcheck.yml
+++ b/.github/workflows/linkcheck.yml
@@ -1,0 +1,21 @@
+name: Linkcheck
+
+on:
+  workflow_dispatch:
+
+jobs:
+  linkcheck:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+        cache: 'pip'
+
+    - run: pip install -r requirements.txt
+
+    - name: Check External Links
+      run: |
+        jupyter-book build docs/ --builder linkcheck

--- a/.github/workflows/rtd-precommit.yml
+++ b/.github/workflows/rtd-precommit.yml
@@ -1,0 +1,47 @@
+name: RTD-Precommit
+# If _config.yml changes, need to update conf.py
+# https://jupyterbook.org/publish/readthedocs.html
+
+on:
+  pull_request:
+    paths:
+      - 'book/_config.yml'
+
+jobs:
+  check_conf_py:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Get changed files using defaults
+      id: changed-files
+      uses: tj-actions/changed-files@v12.2
+
+    - name: Convert _config.yml to conf.py
+      if: contains(steps.changed-files.outputs.modified_files, "conf.py") == false
+      run: |
+        echo "Converting jupyterbook _config.yml to sphinx conf.py for read-the-docs"
+        echo "::set-output name=missing_conf::true"
+
+  commit_conf_py:
+    needs: check_conf_py
+    runs-on: ubuntu-20.04
+    if: ${{needs.check_conf_py.outputs.missing_conf}}
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+        cache: 'pip'
+
+    - run: pip install -r requirements.txt
+
+    - name: Generate conf.py
+      run: |
+        jupyter-book config sphinx book/
+
+    - name: Commit conf.py
+      uses: EndBug/add-and-commit@v7
+      with:
+        default_author: github_actions
+        message: "add book/conf.py"
+        add: book/conf.py

--- a/.github/workflows/spellcheck.yml
+++ b/.github/workflows/spellcheck.yml
@@ -1,0 +1,24 @@
+name: Spellcheck
+
+on:
+  workflow_dispatch:
+
+jobs:
+  spellcheck:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: '3.9'
+        cache: 'pip'
+
+    - run: pip install -r requirements.txt
+
+    # NOTE: this isn't a comprehensive spellcheck, just common typos
+    - name: Spellcheck
+      uses: codespell-project/actions-codespell@master
+      with:
+        check_filenames: true
+        check_hidden: true

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@ https://uwgda-jupyterbook.readthedocs.io
 
 ## local development
 ```
-mamba create -n uwgdabook jupyter-book pre-commit
-mamba activate uwgdabook
+conda create -n uwgdabook jupyter-book pre-commit
+conda activate uwgdabook
 pre-commit install
 ```
 


### PR DESCRIPTION
* Adds 2 actions that can be run 'on-demand' (linkcheck and spellcheck)
* 1 action to ensure an updated `conf.py` is added if `config.yml` is modified. This is nice if you want to make simple changes via the github interface. You avoid having to install pre-commit locally to ensure the files are in sync. caveat is that you must go through a pull request, rather than directly editing the 'main' branch, so enabling branch protection will be a good idea.