### PR TITLE
Codeofconduct edit

### DIFF
--- a/book/_toc.yml
+++ b/book/_toc.yml
@@ -20,6 +20,7 @@ parts:
       - file: resources/github_notes.md
       - file: resources/jupyter_notes.md
     - file: resources/project/README
+    - file: resources/code_of_conduct.md
   - caption: Modules
     chapters:
     - file: modules/01_Shell_Github/README

--- a/book/resources/code_of_conduct.md
+++ b/book/resources/code_of_conduct.md
@@ -106,50 +106,11 @@ violations of UW policy for nondiscrimination can be reported anonymously
 
 ## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines (and associated 
-guidelines for the University of Washington) in determining
-the consequences for any action they deem in violation of this Code of Conduct:
-
-### 1. Correction
-
-**Community Impact**: Use of inappropriate language or other behavior deemed
-unprofessional or unwelcome in the community.
-
-**Consequence**: A private, written warning from community leaders, providing
-clarity around the nature of the violation and an explanation of why the
-behavior was inappropriate. A public apology may be requested.
-
-### 2. Warning
-
-**Community Impact**: A violation through a single incident or series
-of actions.
-
-**Consequence**: A warning with consequences for continued behavior. No
-interaction with the people involved, including unsolicited interaction with
-those enforcing the Code of Conduct, for a specified period of time. This
-includes avoiding interactions in community spaces as well as external channels
-like social media. Violating these terms may lead to a temporary or
-permanent ban.
-
-### 3. Temporary Ban
-
-**Community Impact**: A serious violation of community standards, including
-sustained inappropriate behavior.
-
-**Consequence**: A temporary ban from any sort of interaction or public
-communication with the community for a specified period of time. No public or
-private interaction with the people involved, including unsolicited interaction
-with those enforcing the Code of Conduct, is allowed during this period.
-Violating these terms may lead to a permanent ban.
-
-### 4. Permanent Ban
-
-**Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior, harassment of an
-individual, or aggression toward or disparagement of classes of individuals.
-
-**Consequence**: A permanent ban from any sort of public interaction within
-the community.
+In order to maintain a safe and welcoming environment, when violations of our standards occur, I reserve the right 
+to take corrective actions including but not limited to:
+- some 
+- examples
+- here
 
 ## Attribution
 

--- a/book/resources/code_of_conduct.md
+++ b/book/resources/code_of_conduct.md
@@ -36,6 +36,14 @@ Examples of unacceptable behavior include:
 * Other conduct which could reasonably be considered inappropriate in a
   professional setting
 
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address, 
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
 ## Enforcement Responsibilities
 
 Community leaders are responsible for clarifying and enforcing our standards of
@@ -47,14 +55,6 @@ Community leaders have the right and responsibility to remove, edit, or reject
 comments, commits, code, wiki edits, issues, and other contributions that are
 not aligned to this Code of Conduct, and will communicate reasons for moderation
 decisions when appropriate.
-
-## Scope
-
-This Code of Conduct applies within all community spaces, and also applies when
-an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address, 
-posting via an official social media account, or acting as an appointed
-representative at an online or offline event.
 
 ## Enforcement
 

--- a/book/resources/code_of_conduct.md
+++ b/book/resources/code_of_conduct.md
@@ -5,11 +5,11 @@
 We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
-identity and expression, level of experience, education, socio-economic status,
+identity and expression, level of experience, education, socio-economic status, 
 nationality, personal appearance, race, religion, or sexual identity
 and orientation.
 
-We pledge to act and interact in ways that contribute to an open, welcoming,
+We pledge to act and interact in ways that contribute to an open, welcoming, 
 diverse, inclusive, and healthy community.
 
 ## Our Standards
@@ -20,7 +20,7 @@ community include:
 * Demonstrating empathy and kindness toward other people
 * Being respectful of differing opinions, viewpoints, and experiences
 * Giving and gracefully accepting constructive feedback
-* Accepting responsibility and apologizing to those affected by our mistakes,
+* Accepting responsibility and apologizing to those affected by our mistakes, 
   and learning from the experience
 * Focusing on what is best not just for us as individuals, but for the
   overall community
@@ -40,7 +40,7 @@ Examples of unacceptable behavior include:
 
 Community leaders are responsible for clarifying and enforcing our standards of
 acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive,
+response to any behavior that they deem inappropriate, threatening, offensive, 
 or harmful.
 
 Community leaders have the right and responsibility to remove, edit, or reject
@@ -52,20 +52,57 @@ decisions when appropriate.
 
 This Code of Conduct applies within all community spaces, and also applies when
 an individual is officially representing the community in public spaces.
-Examples of representing our community include using an official e-mail address,
+Examples of representing our community include using an official e-mail address, 
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported to the community leaders responsible for enforcement. 
+Instances of abusive, harassing, or otherwise unacceptable behavior may be 
+reported directly to dshean@uw.edu or a direct message to @dshean on Slack. 
+All complaints will be reviewed and investigated promptly and with respect 
+to the privacy and security of the reporter of any incident.
 
-Please send an email directly to dshean@uw.edu or a direct message to @dshean on Slack.
-All complaints will be reviewed and investigated promptly and fairly.
+Additionally, through numerous policies, UW provides more formal channels 
+for addressing violence, harassment, discrimination, and bias. Bias and 
+violations of UW policy for nondiscrimination can be reported anonymously
+[here][bias reporting]. Sex and gender based violence and harassment is addressed here:
 
-All community leaders are obligated to respect the privacy and security of the
-reporter of any incident.
+> UW, through [numerous policies][title ix], prohibits sex- and gender-based violence 
+> and harassment, and we expect students, faculty, and staff to act professionally
+> and respectfully in all work, learning, and research environments. 
+>
+> For support, resources, and reporting options related to sex- and gender-based
+> violence or harassment, visit [UW Title IX’s webpage][uw title ix page], specifically the [Know Your 
+> Rights & Resources guide][title ix kyr]. 
+> Please know that if you choose to disclose information to me about sex- or 
+> gender-based violence or harassment, I will connect you (or the person who 
+> experienced the conduct) with resources and individuals who can best provide 
+> support and options. You can also access those resources directly:
+> - Confidential: [Confidential advocates][confidential advocates] will not share information with others 
+> unless given express permission by the person who has experienced the harm or 
+> when required by law.
+> - Private and/or anonymous: [SafeCampus][safecampus] provides consultation and support and 
+> can connect you with additional resources if you want them. You can contact 
+> SafeCampus anonymously or share limited information when you call.
+>
+> Please note that some senior leaders and other specified employees have been 
+> identified as “[Officials Required to Report.”][officials req to report] If an Official Required to Report 
+> learns of possible sex- or gender-based violence or harassment, they are required
+> to call SafeCampus and report all the details they have in order to ensure that 
+> the person who experienced harm is offered support and reporting options.  
+>
+> Title IX website: https://www.washington.edu/titleix/
+>
+> Support and help page: https://www.washington.edu/titleix/resources/
+>
+> Confidential advocates: https://www.washington.edu/sexualassault/support/advocacy/
+>
+> SafeCampus: https://www.washington.edu/safecampus/
+>
+> Officials Required to Report: https://www.washington.edu/titleix/title-ix-officials-required-to-report/
+>
+> Related policies: https://www.washington.edu/titleix/policies/
 
 ## Enforcement Guidelines
 
@@ -108,7 +145,7 @@ Violating these terms may lead to a permanent ban.
 ### 4. Permanent Ban
 
 **Community Impact**: Demonstrating a pattern of violation of community
-standards, including sustained inappropriate behavior,  harassment of an
+standards, including sustained inappropriate behavior, harassment of an
 individual, or aggression toward or disparagement of classes of individuals.
 
 **Consequence**: A permanent ban from any sort of public interaction within
@@ -116,7 +153,7 @@ the community.
 
 ## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], 
 version 2.0, available at
 [https://www.contributor-covenant.org/version/2/0/code_of_conduct.html][v2.0].
 
@@ -132,3 +169,10 @@ at [https://www.contributor-covenant.org/translations][translations].
 [Mozilla CoC]: https://github.com/mozilla/diversity
 [FAQ]: https://www.contributor-covenant.org/faq
 [translations]: https://www.contributor-covenant.org/translations
+[bias reporting]: https://www.washington.edu/raceequity/updates/bias-reporting-tools/
+[title ix]: https://www.washington.edu/titleix/policies/
+[uw title ix page]: https://www.washington.edu/titleix/
+[title ix kyr]: https://www.washington.edu/pso/resources/know-your-rights/
+[confidential advocates]: https://www.washington.edu/sexualassault/support/advocacy/
+[safecampus]: https://www.washington.edu/safecampus/
+[officials req to report]: https://www.washington.edu/titleix/title-ix-officials-required-to-report/

--- a/book/resources/code_of_conduct.md
+++ b/book/resources/code_of_conduct.md
@@ -44,18 +44,6 @@ Examples of representing our community include using an official e-mail address,
 posting via an official social media account, or acting as an appointed
 representative at an online or offline event.
 
-## Enforcement Responsibilities
-
-Community leaders are responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior that they deem inappropriate, threatening, offensive, 
-or harmful.
-
-Community leaders have the right and responsibility to remove, edit, or reject
-comments, commits, code, wiki edits, issues, and other contributions that are
-not aligned to this Code of Conduct, and will communicate reasons for moderation
-decisions when appropriate.
-
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be 
@@ -104,13 +92,19 @@ violations of UW policy for nondiscrimination can be reported anonymously
 >
 > Related policies: https://www.washington.edu/titleix/policies/
 
-## Enforcement Guidelines
+## Enforcement Responsibilities & Guidelines
 
-In order to maintain a safe and welcoming environment, when violations of our standards occur, I reserve the right 
-to take corrective actions including but not limited to:
+I am responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior deemed inappropriate, threatening, offensive, 
+or harmful. I will communicate reasons for moderation decisions when appropriate. 
+In order to maintain a safe and welcoming environment, when violations of our 
+standards occur, I reserve the right to take corrective actions including but not 
+limited to:
 - some 
 - examples
 - here
+- remove edits, comments, code, slack messages that are not alligned with this code of conduct
 
 ## Attribution
 

--- a/book/resources/code_of_conduct.md
+++ b/book/resources/code_of_conduct.md
@@ -47,7 +47,7 @@ representative at an online or offline event.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be 
-reported directly to dshean@uw.edu or a direct message to @dshean on Slack. 
+reported directly to the GDA course instructor (dshean@uw.edu or a direct message to @dshean on Slack). 
 All complaints will be reviewed and investigated promptly and with respect 
 to the privacy and security of the reporter of any incident.
 
@@ -63,8 +63,9 @@ violations of UW policy for nondiscrimination can be reported anonymously
 > For support, resources, and reporting options related to sex- and gender-based
 > violence or harassment, visit [UW Title IX’s webpage][uw title ix page], specifically the [Know Your 
 > Rights & Resources guide][title ix kyr]. 
-> Please know that if you choose to disclose information to me about sex- or 
-> gender-based violence or harassment, I will connect you (or the person who 
+> 
+> Please know that if you choose to disclose information to the GDA course instructor about sex- or 
+> gender-based violence or harassment, they will connect you (or the person who 
 > experienced the conduct) with resources and individuals who can best provide 
 > support and options. You can also access those resources directly:
 > - Confidential: [Confidential advocates][confidential advocates] will not share information with others 
@@ -95,13 +96,8 @@ violations of UW policy for nondiscrimination can be reported anonymously
 ## Enforcement Responsibilities & Guidelines
 
 In order to maintain a safe and welcoming environment, when violations of our 
-standards occur, I reserve the right to take appropriate corrective action. 
-I will communicate reasons for moderation decisions when appropriate. 
-Corrective actions include but are not limited to:
-- some 
-- examples
-- here
-- remove edits, comments, code, slack messages that are not alligned with this code of conduct
+standards occur, the GDA course instructor reserves the right to take appropriate corrective action, 
+and will communicate reasons for moderation decisions when appropriate. 
 
 ## Attribution
 

--- a/book/resources/code_of_conduct.md
+++ b/book/resources/code_of_conduct.md
@@ -94,13 +94,10 @@ violations of UW policy for nondiscrimination can be reported anonymously
 
 ## Enforcement Responsibilities & Guidelines
 
-I am responsible for clarifying and enforcing our standards of
-acceptable behavior and will take appropriate and fair corrective action in
-response to any behavior deemed inappropriate, threatening, offensive, 
-or harmful. I will communicate reasons for moderation decisions when appropriate. 
 In order to maintain a safe and welcoming environment, when violations of our 
-standards occur, I reserve the right to take corrective actions including but not 
-limited to:
+standards occur, I reserve the right to take appropriate corrective action. 
+I will communicate reasons for moderation decisions when appropriate. 
+Corrective actions include but are not limited to:
 - some 
 - examples
 - here

--- a/book/resources/code_of_conduct.md
+++ b/book/resources/code_of_conduct.md
@@ -1,4 +1,4 @@
-# GDA Course Code of Conduct
+# Code of Conduct
 
 ## Our Pledge
 


### PR DESCRIPTION
Made changes to code of conduct. Included UW title ix resources and bias / violations of nondiscrim reporting. Restructured and removed irrelevant info such as community impact guidelines and replaced with more relevant corrective actions. For David, I left the example bullet blank at the bottom for potential corrective actions based on what you're comfortable with.