### PR TITLE
Using the predicate argument for spatial join

### DIFF
--- a/book/modules/06_Vector2_Geometries_SpatialOps_Viz/06_Vector2_Geometries_SpatialOps_Viz_exercises.ipynb
+++ b/book/modules/06_Vector2_Geometries_SpatialOps_Viz/06_Vector2_Geometries_SpatialOps_Viz_exercises.ipynb
@@ -753,7 +753,7 @@
    "source": [
     "### Now try a spatial join between these two \n",
     "* Use the GLAS points as the \"left\" GeoDataFrame and the States as the \"right\" GeoDataFrame\n",
-    "* Start by using default options (`op='intersects', how='inner'`)\n",
+    "* Start by using default options (`predicate='intersects', how='inner'`)\n",
     "* Note the output geometry type and columns"
    ]
   },


### PR DESCRIPTION
Using the `op` argument is depricated as per the following warning:
```
FutureWarning: The `op` parameter is deprecated and will be removed in a future release. Please use the `predicate` parameter instead.
  if await self.run_code(code, result, async_=asy):
```

the [documentation](https://geopandas.org/en/stable/docs/reference/api/geopandas.sjoin.html) suggest the use of `predicate` rather.